### PR TITLE
Make sure flaggings are destroyed with flaggable

### DIFF
--- a/lib/make_flaggable/flaggable.rb
+++ b/lib/make_flaggable/flaggable.rb
@@ -3,7 +3,7 @@ module MakeFlaggable
     extend ActiveSupport::Concern
 
     included do
-      has_many :flaggings, :class_name => "MakeFlaggable::Flagging", :as => :flaggable
+      has_many :flaggings, :class_name => "MakeFlaggable::Flagging", :as => :flaggable, dependent: :destroy
     end
 
     module ClassMethods

--- a/spec/lib/make_flaggable_spec.rb
+++ b/spec/lib/make_flaggable_spec.rb
@@ -116,7 +116,7 @@ describe "Make Flaggable" do
 
       context 'Argument passed' do
         it 'returns flaggers who have flagged a particular flaggable resource' do
-          FlaggerModel.flaggers(FlaggableModel).should == [@flagger] 
+          FlaggerModel.flaggers(FlaggableModel).should == [@flagger]
         end
 
         it 'returns nothing if no flag is found' do
@@ -140,6 +140,13 @@ describe "Make Flaggable" do
       @flaggable.flagged?.should == true
       @flagger.unflag!(@flaggable)
       @flaggable.flagged?.should == false
+    end
+
+    it "should destroy flagging when flaggable is destroyed" do
+      @flagger.flag!(@flaggable)
+      MakeFlaggable::Flagging.count.should == 1
+      @flaggable.destroy
+      MakeFlaggable::Flagging.count.should == 0
     end
   end
 end


### PR DESCRIPTION
This PR updates the `flaggable` - `has_many :flaggings` relation to make sure that we don't end up with orphan flaggings when destroying a flaggable.

We do so by adding the missing `dependent: destroy` instruction.